### PR TITLE
Fix random sorting of files with same size

### DIFF
--- a/lib/torrent_detail/files/torrent_files.dart
+++ b/lib/torrent_detail/files/torrent_files.dart
@@ -213,7 +213,7 @@ class _TorrentFileListState extends State<_TorrentFileList>
         onTap: onParentClicked,
       ));
     }
-    currentDirectory.children.sort((f1, f2) => f2.size.compareTo(f1.size));
+    currentDirectory.children.sort((f1, f2) => f1.path.compareTo(f2.path));
     for (var file in currentDirectory.children) {
       var isSelected = selectedFiles.contains(file);
       var isSelectionMode = selectedFiles.isNotEmpty;


### PR DESCRIPTION
 Fix random sorting of files with same size by using path instead in torrent details view, files tab.