### PR TITLE
Fix: don't dispose the client from the event-subscription teardown

### DIFF
--- a/lib/common/trireme_repository.dart
+++ b/lib/common/trireme_repository.dart
@@ -66,7 +66,6 @@ class TriremeRepository {
           client.delugeRpcEvents().listen((e) => _eventsStream?.add(e));
     } else {
       _localEventSubscription?.cancel();
-      _client?.dispose();
     }
   }
 


### PR DESCRIPTION
Root cause of the missing-torrent report, found via low-level socket tracing on a real device: ClientProviderState.reInitClient calls setClient(null) and then, in the same synchronous stretch, calls client.init() again on the same instance. setClient(null) only schedules the widget rebuild that reaches this repository's client setter - it doesn't run inline - so by the time that rebuild's null branch actually executes, client.init() has already replaced the client's internal event stream controller. Disposing the client there closed the brand-new controller instead of the old one, permanently, so no daemon-pushed event (add, remove, state change, ...) was ever delivered again after the first app background/foreground cycle - which is trivially triggered by something as ordinary as the system file picker used to add a torrent from a file.

Traced with git blame: the dispose call was added in a 2021 null-safety migration with no awareness of reInitClient's sequencing (which predates it by three years); the only other paths that null this out already dispose the client themselves beforehand, so this dispose call had no remaining legitimate purpose.

Fixes #81 